### PR TITLE
add: ability to download .pcap log

### DIFF
--- a/src/lib/vizualize/Summary.svelte
+++ b/src/lib/vizualize/Summary.svelte
@@ -23,9 +23,21 @@ summary.subscribe(val => {
 
 async function download(name) {
   let resp = await api.get('trace', {
-    name: name
+    responseType: 'blob',
+    params: {
+      name: name
+    }
   });
-  console.log(resp);
+  const blob = resp.data;
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.style.display = "none";
+  a.href = url;
+        
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(url); 
 }
 
 </script>


### PR DESCRIPTION
- uri parameters now working
- response is a blob
- download on click

![image](https://user-images.githubusercontent.com/55835897/204373679-976c1673-6297-4d91-9510-0d1c51f5df9a.png)
