### PR TITLE
:cool: :id: smol bug, ktorý robil bordel

### DIFF
--- a/src/lib/network/Network.svelte
+++ b/src/lib/network/Network.svelte
@@ -11,7 +11,7 @@
     function clickHandler() {
         isShown = !isShown
         if (isShown) 
-        visibleNetwork.set(network.ssid)
+        visibleNetwork.set(network.id)
     }
   
     function handleClosing() {
@@ -32,7 +32,7 @@
     }
     
     // MAGIC
-    $: open = ($visibleNetwork == network.ssid) ? 
+    $: open = ($visibleNetwork == network.id) ? 
             (isShown) ? 
               true
             : false


### PR DESCRIPTION
Formulár siete pri zmene mena sa zatváral preto, lebo akonáhle sa meno nezhodovalo s menom siete, ktorá má byť otvorená, tak sa má zavrieť. Fix tak, že sa kontroluje id. :pain: